### PR TITLE
Countopt

### DIFF
--- a/kernels/common.cl
+++ b/kernels/common.cl
@@ -372,6 +372,7 @@ kernel void find_particle_bins (PSO_ARGS) {
                      (uint3) (gridres[0]-1, gridres[1]-1, gridres[2]-1));
 
     gridcell[i] = gc.z * gridres[0] * gridres[1] + gc.y * gridres[0] + gc.x;
+    atomic_inc (&gridcount[gridcell[i]]);
 }
 kernel void zero_gridcount (PSO_ARGS) {
     USE_FIELD(gridcount, uint) USE_FIELD(gridres, uint)

--- a/profiling/avgTimes.sh
+++ b/profiling/avgTimes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+FILE=$1
+
+avg()
+{
+	if [ -z "$1" ]; then
+		n=1
+	else
+		n=$1
+	fi
+	awk "function isnum(x){return(x==x+0)} { if(isnum(\$$n)) { sum+=\$$n; sumsq+=\$$n*\$$n ; n+=1;} } END { print sum/n, sum, n, sqrt(sumsq/n - sum*sum/n/n) }"
+}
+
+sum() {
+	grep $1 $2 | cut -f 2 | avg
+}
+
+FUNCTIONS="benchmark-populate_position_cuboid_device_opencl
+benchmark-init_original_position
+benchmark-rotate_particles_device_opencl
+benchmark-zero_gridcount
+benchmark-bin_and_count_device_opencl
+benchmark-prefix_sum_device_opencl
+benchmark-copy_celloffset_to_backup_device_opencl
+benchmark-insert_particles_in_bin_array_device_opencl
+benchmark-compute_original_density
+benchmark-compute_density
+benchmark-compute_rotations_and_strains
+benchmark-compute_stresses
+benchmark-compute_forces_solids
+"
+
+# print table of:
+# $function, avgTime, sumTime, count, stdevTime
+
+for f in $FUNCTIONS ; do
+	echo $f | tr '\n' '\t'
+	sum $f $FILE | tr ' ' '\t'
+done

--- a/src/opencl/particle_system_host.c
+++ b/src/opencl/particle_system_host.c
@@ -358,15 +358,14 @@ static void bin_and_count_device_opencl(psdata_opencl pso)
 
     ASSERT(find_particle_bins != NULL && count_particles_in_bins != NULL);
 
+    zero_gridcount_device_opencl(pso);
+
     HANDLE_CL_ERROR(clEnqueueNDRangeKernel(_command_queues[0], find_particle_bins, 1,
                                            NULL, &num_p_workitems, &pso.po2_workgroup_size, 0, NULL, NULL));
 
-    HANDLE_CL_ERROR(clFinish(_command_queues[0]));
-
-    zero_gridcount_device_opencl(pso);
-
-    HANDLE_CL_ERROR(clEnqueueNDRangeKernel(_command_queues[0], count_particles_in_bins, 1,
-                                           NULL, &num_p_workitems, &pso.po2_workgroup_size, 0, NULL, NULL));
+	// functionality contained in find_particle_bins
+    /* HANDLE_CL_ERROR(clEnqueueNDRangeKernel(_command_queues[0], count_particles_in_bins, 1, */
+    /*                                        NULL, &num_p_workitems, &pso.po2_workgroup_size, 0, NULL, NULL)); */
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
 	timeStop(bin_and_count_device_opencl)

--- a/src/opencl/particle_system_host.c
+++ b/src/opencl/particle_system_host.c
@@ -90,10 +90,9 @@ printf("chk4.2 ");
 
     HANDLE_CL_ERROR(error);
 
-    _command_queues     = malloc(_platforms[target_platform].num_devices*sizeof(cl_command_queue)); // replaced [0] with target_platform
-    _num_command_queues = _platforms[target_platform].num_devices; // replaced [0] with [target_platform]
-
+    _num_command_queues = _platforms[target_platform].num_devices;
     ASSERT(_num_command_queues > 0);
+    _command_queues     = malloc(_num_command_queues*sizeof(cl_command_queue));
     
     // JD added, determine max worker size during long time to avoid crashing on Intel Integrated GPU  
 
@@ -101,10 +100,10 @@ printf("chk4.2 ");
 
     // Find the maximum dimensions of the work-groups
     cl_uint num; 
-    clGetDeviceInfo(devices[0], CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, sizeof(cl_uint), &num, NULL);
+    clGetDeviceInfo(devices[target_device], CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, sizeof(cl_uint), &num, NULL);
     // Get the max. dimensions of the work-groups
     size_t dims[num];
-    clGetDeviceInfo(devices[0], CL_DEVICE_MAX_WORK_ITEM_SIZES, sizeof(dims), &dims, NULL);
+    clGetDeviceInfo(devices[target_device], CL_DEVICE_MAX_WORK_ITEM_SIZES, sizeof(dims), &dims, NULL);
     max_work_item_size = dims[0]; // For now just take the first dimension;
     printf("The Device specific maximum work item size is %u \n", dims[0]);
   

--- a/src/opencl/particle_system_host.c
+++ b/src/opencl/particle_system_host.c
@@ -12,6 +12,7 @@
 #include "../particle_system.h"
 #include "../note.h"
 #include "platforminfo.h"
+#include "../microbenchmark.h"
 
 #define NUM_PS_ARGS 10
 
@@ -172,6 +173,8 @@ void call_kernel_device_opencl(psdata_opencl pso, const char * kernel_name, cl_u
                                const size_t * global_work_offset, const size_t * global_work_size,
                                const size_t * local_work_size)
 {
+	timeInit(call_kernel_device_opencl)
+	timeStart(call_kernel_device_opencl)
     cl_kernel kernel = get_kernel(pso, kernel_name);
 
     ASSERT(kernel != NULL);
@@ -182,6 +185,7 @@ void call_kernel_device_opencl(psdata_opencl pso, const char * kernel_name, cl_u
                                            global_work_size, NULL, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStopS(call_kernel_device_opencl, kernel_name)
 }
 
 void build_program(psdata * data, psdata_opencl * pso, const char * file_list)
@@ -340,6 +344,8 @@ static void zero_gridcount_device_opencl(psdata_opencl pso)
 
 static void bin_and_count_device_opencl(psdata_opencl pso)
 {
+	timeInit(bin_and_count_device_opencl)
+	timeStart(bin_and_count_device_opencl)
     unsigned int * pnum_ptr;
 
     PS_GET_FIELD(pso.host_psdata, "pnum", unsigned int, &pnum_ptr)
@@ -364,10 +370,13 @@ static void bin_and_count_device_opencl(psdata_opencl pso)
                                            NULL, &num_p_workitems, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(bin_and_count_device_opencl)
 }
 
 static void prefix_sum_device_opencl(psdata_opencl pso)
 {
+	timeInit(prefix_sum_device_opencl)
+	timeStart(prefix_sum_device_opencl)
     cl_kernel prefix_sum = get_kernel(pso, "prefix_sum");
 
     ASSERT(prefix_sum != NULL);
@@ -379,10 +388,13 @@ static void prefix_sum_device_opencl(psdata_opencl pso)
                                                &num_work_items, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(prefix_sum_device_opencl)
 }
 
 static void copy_celloffset_to_backup_device_opencl(psdata_opencl pso)
 {
+	timeInit(copy_celloffset_to_backup_device_opencl)
+	timeStart(copy_celloffset_to_backup_device_opencl)
     cl_kernel copy_celloffset_to_backup = get_kernel(pso, "copy_celloffset_to_backup");
 
     ASSERT(copy_celloffset_to_backup != NULL);
@@ -392,10 +404,13 @@ static void copy_celloffset_to_backup_device_opencl(psdata_opencl pso)
     HANDLE_CL_ERROR(clEnqueueNDRangeKernel(_command_queues[0], copy_celloffset_to_backup, 1, NULL, &num_work_items, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(copy_celloffset_to_backup_device_opencl)
 }
 
 static void insert_particles_in_bin_array_device_opencl(psdata_opencl pso)
 {
+	timeInit(insert_particles_in_bin_array_device_opencl)
+	timeStart(insert_particles_in_bin_array_device_opencl)
     int * pnum_ptr;
 
     PS_GET_FIELD(pso.host_psdata, "pnum", int, &pnum_ptr);
@@ -411,6 +426,7 @@ static void insert_particles_in_bin_array_device_opencl(psdata_opencl pso)
     HANDLE_CL_ERROR(clEnqueueNDRangeKernel(_command_queues[0], insert_particles_in_bin_array, 1, NULL, &num_work_items, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(insert_particles_in_bin_array_device_opencl)
 }
 
 void compute_particle_bins_device_opencl(psdata_opencl pso)
@@ -423,6 +439,8 @@ void compute_particle_bins_device_opencl(psdata_opencl pso)
 
 void compute_density_device_opencl(psdata_opencl pso)
 {
+	timeInit(compute_density_device_opencl)
+	timeStart(compute_density_device_opencl)
     unsigned int * n_ptr;
 
     PS_GET_FIELD(pso.host_psdata, "n", unsigned int, &n_ptr);
@@ -440,10 +458,13 @@ void compute_density_device_opencl(psdata_opencl pso)
                                            &num_workitems, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(compute_density_device_opencl)
 }
 
 void compute_forces_device_opencl(psdata_opencl pso)
 {
+	timeInit(compute_forces_device_opencl)
+	timeStart(compute_forces_device_opencl)
     unsigned int * n_ptr;
 
     PS_GET_FIELD(pso.host_psdata, "n", unsigned int, &n_ptr);
@@ -460,10 +481,13 @@ void compute_forces_device_opencl(psdata_opencl pso)
                                            &num_workitems, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(compute_forces_device_opencl)
 }
 
 void step_forward_device_opencl(psdata_opencl pso)
 {
+	timeInit(step_forward_device_opencl)
+	timeStart(step_forward_device_opencl)
     unsigned int * n_ptr;
 
     PS_GET_FIELD(pso.host_psdata, "n", unsigned int, &n_ptr);
@@ -480,6 +504,7 @@ void step_forward_device_opencl(psdata_opencl pso)
                                            &num_workitems, &pso.po2_workgroup_size, 0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(step_forward_device_opencl)
 }
 
 void call_for_all_particles_device_opencl(psdata_opencl pso, const char * kernel_name)
@@ -501,6 +526,8 @@ void populate_position_cuboid_device_opencl(psdata_opencl pso,
                                             unsigned int ysize,
                                             unsigned int zsize)
 {
+	timeInit(populate_position_cuboid_device_opencl)
+	timeStart(populate_position_cuboid_device_opencl)
     size_t work_group_edge = (size_t) pow
         ((REAL) _platforms[target_platform].devices[target_device].max_workgroup_size, 1.0/3.0);//replaced [0] with [target_platform] ... [target_device]
     size_t local_work_size[] = { work_group_edge, work_group_edge, work_group_edge };
@@ -524,10 +551,13 @@ void populate_position_cuboid_device_opencl(psdata_opencl pso,
                                            global_work_size, local_work_size,
                                            0, NULL, NULL));
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(populate_position_cuboid_device_opencl)
 }
 
 void rotate_particles_device_opencl(psdata_opencl pso, REAL angle_x, REAL angle_y, REAL angle_z)
 {
+	timeInit(rotate_particles_device_opencl)
+	timeStart(rotate_particles_device_opencl)
     unsigned int * pN;
 
     PS_GET_FIELD(pso.host_psdata, "n", unsigned int, &pN);
@@ -550,6 +580,7 @@ void rotate_particles_device_opencl(psdata_opencl pso, REAL angle_x, REAL angle_
                                            0, NULL, NULL));
 
     HANDLE_CL_ERROR(clFinish(_command_queues[0]));
+	timeStop(rotate_particles_device_opencl)
 }
 
 /**

--- a/src/testopencl.c
+++ b/src/testopencl.c
@@ -36,7 +36,11 @@ int main(int argc, char *argv[])
     REAL * originalpos;
     REAL * density0;
     REAL * rotation;
+#ifndef OPENCL_SPH_MICROBENCHMARK
     uint numSteps = 2000;
+#else
+    uint numSteps = 10;
+#endif
 
     PS_GET_FIELD(data, "position", REAL, &position);
     PS_GET_FIELD(data, "originalpos", REAL, &originalpos);
@@ -69,9 +73,14 @@ for(int i = 0; i<numSteps;i++)
             call_for_all_particles_device_opencl(pso, "step_forward");
         
             sync_psdata_device_to_host(data, pso);
+#ifndef OPENCL_SPH_MICROBENCHMARK
 	    write_psdata(data, i, "solid");
+#endif
 }
-        free_psdata_opencl(&pso);
+#ifdef OPENCL_SPH_MICROBENCHMARK
+	write_psdata(data, numSteps-1, "solid");
+#endif
+	free_psdata_opencl(&pso);
     if (verbose) printf(" chk13 "); 
     terminate_opencl();
     if (verbose) printf(" chk14 "); 


### PR DESCRIPTION
This contains some code to timing the host functions which call kernels. This can be turned on by defining the macro OPENCL_SPH_MICROBENCHMARKING .
(use ccmake to set CMAKE_C_FLAGS)

This also contains a small optimization in the particle counting which merges the count_particles_in_bins kernel into the find_particle_bins kernel.  